### PR TITLE
fix: easyocr byte string issues

### DIFF
--- a/kreuzberg/_ocr/_easyocr.py
+++ b/kreuzberg/_ocr/_easyocr.py
@@ -4,7 +4,6 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, ClassVar, Final, Literal
 
 from PIL import Image
-import numpy as np
 
 from kreuzberg._mime_types import PLAIN_TEXT_MIME_TYPE
 from kreuzberg._ocr._base import OCRBackend
@@ -171,6 +170,8 @@ class EasyOCRBackend(OCRBackend[EasyOCRConfig]):
         Raises:
             OCRError: If OCR processing fails.
         """
+        import numpy as np
+
         await self._init_easyocr(**kwargs)
 
         beam_width = kwargs.pop("beam_width")

--- a/kreuzberg/_ocr/_easyocr.py
+++ b/kreuzberg/_ocr/_easyocr.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, ClassVar, Final, Literal
 
 from PIL import Image
+import numpy as np
 
 from kreuzberg._mime_types import PLAIN_TEXT_MIME_TYPE
 from kreuzberg._ocr._base import OCRBackend
@@ -180,7 +181,7 @@ class EasyOCRBackend(OCRBackend[EasyOCRConfig]):
         try:
             result = await run_sync(
                 self._reader.readtext,
-                image.tobytes(),
+                np.array(image),
                 beamWidth=beam_width,
                 **kwargs,
             )


### PR DESCRIPTION
Fixed image passing to the easyocr backend by using an nparray instead of bytes