### PR TITLE
feat: Add comprehensive CLI support with Click framework (#63)

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Kreuzberg is a Python library for text extraction from documents. It provides a 
 - **Resource Efficient**: Lightweight processing without GPU requirements
 - **Format Support**: Comprehensive support for documents, images, and text formats
 - **Multiple OCR Engines**: Support for Tesseract, EasyOCR, and PaddleOCR
+- **Command Line Interface**: Powerful CLI for batch processing and automation
 - **Metadata Extraction**: Get document metadata alongside text content
 - **Table Extraction**: Extract tables from documents using the excellent GMFT library
 - **Modern Python**: Built with async/await, type hints, and a functional-first approach
@@ -23,6 +24,9 @@ Kreuzberg is a Python library for text extraction from documents. It provides a 
 
 ```bash
 pip install kreuzberg
+
+# Or install with CLI support
+pip install "kreuzberg[cli]"
 ```
 
 Install pandoc:
@@ -72,12 +76,53 @@ async def main():
 asyncio.run(main())
 ```
 
+## Command Line Interface
+
+Kreuzberg includes a powerful CLI for processing documents from the command line:
+
+```bash
+# Extract text from a file
+kreuzberg extract document.pdf
+
+# Extract with JSON output and metadata
+kreuzberg extract document.pdf --output-format json --show-metadata
+
+# Extract from stdin
+cat document.html | kreuzberg extract
+
+# Use specific OCR backend
+kreuzberg extract image.png --ocr-backend easyocr --easyocr-languages en,de
+
+# Extract with configuration file
+kreuzberg extract document.pdf --config config.toml
+```
+
+### CLI Configuration
+
+Configure via `pyproject.toml`:
+
+```toml
+[tool.kreuzberg]
+force_ocr = true
+chunk_content = false
+extract_tables = true
+max_chars = 4000
+ocr_backend = "tesseract"
+
+[tool.kreuzberg.tesseract]
+language = "eng+deu"
+psm = 3
+```
+
+For full CLI documentation, see the [CLI Guide](https://goldziher.github.io/kreuzberg/cli/).
+
 ## Documentation
 
 For comprehensive documentation, visit our [GitHub Pages](https://goldziher.github.io/kreuzberg/):
 
 - [Getting Started](https://goldziher.github.io/kreuzberg/getting-started/) - Installation and basic usage
 - [User Guide](https://goldziher.github.io/kreuzberg/user-guide/) - In-depth usage information
+- [CLI Guide](https://goldziher.github.io/kreuzberg/cli/) - Command-line interface documentation
 - [API Reference](https://goldziher.github.io/kreuzberg/api-reference/) - Detailed API documentation
 - [Examples](https://goldziher.github.io/kreuzberg/examples/) - Code examples for common use cases
 - [OCR Configuration](https://goldziher.github.io/kreuzberg/user-guide/ocr-configuration/) - Configure OCR engines

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,0 +1,190 @@
+# CLI Usage
+
+The Kreuzberg CLI provides a convenient command-line interface for text extraction from documents.
+
+## Installation
+
+Install Kreuzberg with CLI support:
+
+```bash
+pip install kreuzberg[cli]
+```
+
+Or install all optional dependencies:
+
+```bash
+pip install kreuzberg[all]
+```
+
+## Basic Usage
+
+### Extract from a file
+
+```bash
+kreuzberg extract document.pdf
+```
+
+### Extract to a file
+
+```bash
+kreuzberg extract document.pdf -o output.txt
+```
+
+### Extract from stdin
+
+```bash
+cat document.pdf | kreuzberg extract
+# or
+kreuzberg extract -
+```
+
+## Command-Line Options
+
+### General Options
+
+- `-o, --output PATH`: Output file path (default: stdout)
+- `--output-format [text|json]`: Output format
+- `--show-metadata`: Include metadata in output
+- `-v, --verbose`: Verbose output for debugging
+
+### Processing Options
+
+- `--force-ocr`: Force OCR processing
+- `--chunk-content`: Enable content chunking
+- `--extract-tables`: Enable table extraction
+- `--max-chars INTEGER`: Maximum characters per chunk (default: 2000)
+- `--max-overlap INTEGER`: Maximum overlap between chunks (default: 100)
+
+### OCR Backend Options
+
+- `--ocr-backend [tesseract|easyocr|paddleocr|none]`: OCR backend to use
+
+#### Tesseract Options
+
+- `--tesseract-lang TEXT`: Language(s) (e.g., 'eng+deu')
+- `--tesseract-psm INTEGER`: PSM mode (0-13)
+
+#### EasyOCR Options
+
+- `--easyocr-languages TEXT`: Language codes (comma-separated, e.g., 'en,de')
+
+#### PaddleOCR Options
+
+- `--paddleocr-languages TEXT`: Language codes (comma-separated, e.g., 'en,german')
+
+## Configuration File
+
+Kreuzberg can load configuration from a `pyproject.toml` file:
+
+```toml
+[tool.kreuzberg]
+force_ocr = false
+chunk_content = true
+extract_tables = false
+max_chars = 5000
+ocr_backend = "tesseract"
+
+[tool.kreuzberg.tesseract]
+language = "eng+deu"
+psm = 3
+
+[tool.kreuzberg.gmft]
+verbosity = 1
+cell_required_confidence = 50
+```
+
+Use a specific config file:
+
+```bash
+kreuzberg extract document.pdf --config custom-config.toml
+```
+
+## Examples
+
+### Basic text extraction
+
+```bash
+kreuzberg extract report.pdf -o report.txt
+```
+
+### OCR with specific language
+
+```bash
+kreuzberg extract scan.jpg --force-ocr --tesseract-lang deu
+```
+
+### Extract tables to JSON
+
+```bash
+kreuzberg extract spreadsheet.pdf --extract-tables --output-format json -o tables.json
+```
+
+### Extract with metadata
+
+```bash
+kreuzberg extract document.pdf --show-metadata --output-format json
+```
+
+### Using EasyOCR backend
+
+```bash
+kreuzberg extract image.png --ocr-backend easyocr --easyocr-languages en,de
+```
+
+### Extract with chunking
+
+```bash
+kreuzberg extract large-document.pdf --chunk-content --max-chars 1000
+```
+
+## Module Execution
+
+You can also run Kreuzberg as a Python module:
+
+```bash
+python -m kreuzberg extract document.pdf
+```
+
+## Command Reference
+
+### `kreuzberg extract`
+
+Extract text from a document.
+
+**Usage:**
+
+```bash
+kreuzberg extract [OPTIONS] [FILE]
+```
+
+**Arguments:**
+
+- `FILE`: Path to document or '-' for stdin (optional, defaults to stdin)
+
+### `kreuzberg config`
+
+Show current configuration.
+
+**Usage:**
+
+```bash
+kreuzberg config [OPTIONS]
+```
+
+**Options:**
+
+- `--config PATH`: Configuration file path
+
+### `kreuzberg --version`
+
+Show version information.
+
+## Error Handling
+
+The CLI provides clear error messages:
+
+- Exit code 0: Success
+- Exit code 1: General error (parsing, validation, etc.)
+- Exit code 2: Missing dependency error
+
+Use `--verbose` for detailed error information and stack traces.

--- a/kreuzberg/__init__.py
+++ b/kreuzberg/__init__.py
@@ -18,6 +18,8 @@ from .extraction import (
     extract_file_sync,
 )
 
+__version__ = "3.2.0"
+
 __all__ = [
     "EasyOCRConfig",
     "ExtractionConfig",
@@ -34,6 +36,7 @@ __all__ = [
     "TableData",
     "TesseractConfig",
     "ValidationError",
+    "__version__",
     "batch_extract_bytes",
     "batch_extract_bytes_sync",
     "batch_extract_file",

--- a/kreuzberg/__main__.py
+++ b/kreuzberg/__main__.py
@@ -1,0 +1,8 @@
+"""Entry point for running kreuzberg as a module with python -m kreuzberg."""
+
+from __future__ import annotations
+
+from kreuzberg.cli import cli
+
+if __name__ == "__main__":
+    cli()

--- a/kreuzberg/_cli_config.py
+++ b/kreuzberg/_cli_config.py
@@ -1,0 +1,189 @@
+"""Configuration parsing for the CLI."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+if sys.version_info >= (3, 11):
+    import tomllib
+else:
+    import tomli as tomllib  # type: ignore[import-not-found]
+
+from kreuzberg._gmft import GMFTConfig
+from kreuzberg._ocr._easyocr import EasyOCRConfig
+from kreuzberg._ocr._paddleocr import PaddleOCRConfig
+from kreuzberg._ocr._tesseract import TesseractConfig
+from kreuzberg._types import ExtractionConfig, OcrBackendType
+from kreuzberg.exceptions import ValidationError
+
+if TYPE_CHECKING:
+    from collections.abc import MutableMapping
+
+
+def load_config_from_file(config_path: Path) -> dict[str, Any]:
+    """Load configuration from a TOML file.
+
+    Args:
+        config_path: Path to the configuration file.
+
+    Returns:
+        Dictionary containing the loaded configuration.
+
+    Raises:
+        ValidationError: If the file cannot be read or parsed.
+    """
+    try:
+        with config_path.open("rb") as f:
+            data = tomllib.load(f)
+    except FileNotFoundError as e:
+        raise ValidationError(f"Configuration file not found: {config_path}") from e
+    except tomllib.TOMLDecodeError as e:
+        raise ValidationError(f"Invalid TOML in configuration file: {e}") from e
+
+    # Extract kreuzberg-specific configuration
+    return data.get("tool", {}).get("kreuzberg", {})  # type: ignore[no-any-return]
+
+
+def merge_configs(base: dict[str, Any], override: dict[str, Any]) -> dict[str, Any]:
+    """Merge two configuration dictionaries recursively.
+
+    Args:
+        base: Base configuration dictionary.
+        override: Configuration dictionary to override base values.
+
+    Returns:
+        Merged configuration dictionary.
+    """
+    result = base.copy()
+    for key, value in override.items():
+        if isinstance(value, dict) and key in result and isinstance(result[key], dict):
+            result[key] = merge_configs(result[key], value)
+        else:
+            result[key] = value
+    return result
+
+
+def parse_ocr_backend_config(
+    config_dict: dict[str, Any], backend: OcrBackendType
+) -> TesseractConfig | EasyOCRConfig | PaddleOCRConfig | None:
+    """Parse OCR backend-specific configuration.
+
+    Args:
+        config_dict: Configuration dictionary.
+        backend: The OCR backend type.
+
+    Returns:
+        Backend-specific configuration object or None.
+    """
+    if backend not in config_dict:
+        return None
+
+    backend_config = config_dict[backend]
+    if not isinstance(backend_config, dict):
+        return None
+
+    if backend == "tesseract":
+        return TesseractConfig(**backend_config)
+    if backend == "easyocr":
+        return EasyOCRConfig(**backend_config)
+    if backend == "paddleocr":
+        return PaddleOCRConfig(**backend_config)
+    return None
+
+
+def build_extraction_config(  # noqa: C901, PLR0912
+    file_config: dict[str, Any],
+    cli_args: MutableMapping[str, Any],
+) -> ExtractionConfig:
+    """Build ExtractionConfig from file config and CLI arguments.
+
+    Args:
+        file_config: Configuration loaded from file.
+        cli_args: CLI arguments.
+
+    Returns:
+        ExtractionConfig instance.
+    """
+    # Start with default values
+    config_dict: dict[str, Any] = {}
+
+    # Apply file configuration
+    if file_config:
+        # Map direct fields
+        for field in ["force_ocr", "chunk_content", "extract_tables", "max_chars", "max_overlap", "ocr_backend"]:
+            if field in file_config:
+                config_dict[field] = file_config[field]
+
+    # Apply CLI overrides
+    for field in ["force_ocr", "chunk_content", "extract_tables", "max_chars", "max_overlap", "ocr_backend"]:
+        cli_key = field
+        if cli_key in cli_args and cli_args[cli_key] is not None:
+            config_dict[field] = cli_args[cli_key]
+
+    # Handle OCR backend configuration
+    ocr_backend = config_dict.get("ocr_backend")
+    if ocr_backend and ocr_backend != "none":
+        # Try CLI args first, then file config
+        ocr_config = None
+
+        # Check for backend-specific CLI args
+        if cli_args.get(f"{ocr_backend}_config"):
+            backend_args = cli_args[f"{ocr_backend}_config"]
+            if ocr_backend == "tesseract":
+                ocr_config = TesseractConfig(**backend_args)
+            elif ocr_backend == "easyocr":
+                ocr_config = EasyOCRConfig(**backend_args)  # type: ignore[assignment]
+            elif ocr_backend == "paddleocr":
+                ocr_config = PaddleOCRConfig(**backend_args)  # type: ignore[assignment]
+
+        # Fall back to file config
+        if not ocr_config and file_config:
+            ocr_config = parse_ocr_backend_config(file_config, ocr_backend)  # type: ignore[assignment]
+
+        if ocr_config:
+            config_dict["ocr_config"] = ocr_config
+
+    # Handle GMFT configuration
+    if config_dict.get("extract_tables"):
+        gmft_config = None
+
+        # Check CLI args
+        if cli_args.get("gmft_config"):
+            gmft_config = GMFTConfig(**cli_args["gmft_config"])
+        # Fall back to file config
+        elif "gmft" in file_config and isinstance(file_config["gmft"], dict):
+            gmft_config = GMFTConfig(**file_config["gmft"])
+
+        if gmft_config:
+            config_dict["gmft_config"] = gmft_config
+
+    # Convert ocr_backend string to None if "none"
+    if config_dict.get("ocr_backend") == "none":
+        config_dict["ocr_backend"] = None
+
+    return ExtractionConfig(**config_dict)
+
+
+def find_default_config() -> Path | None:
+    """Find the default configuration file (pyproject.toml).
+
+    Returns:
+        Path to the configuration file or None if not found.
+    """
+    # Look for pyproject.toml in current directory and parent directories
+    current = Path.cwd()
+    while current != current.parent:
+        config_path = current / "pyproject.toml"
+        if config_path.exists():
+            # Check if it contains kreuzberg configuration
+            try:
+                with config_path.open("rb") as f:
+                    data = tomllib.load(f)
+                if "tool" in data and "kreuzberg" in data["tool"]:
+                    return config_path
+            except Exception:  # noqa: S110, BLE001
+                pass
+        current = current.parent
+    return None

--- a/kreuzberg/cli.py
+++ b/kreuzberg/cli.py
@@ -1,0 +1,352 @@
+"""Command-line interface for kreuzberg."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+try:
+    import click
+    from rich.console import Console
+    from rich.progress import Progress, SpinnerColumn, TextColumn
+except ImportError as e:
+    raise ImportError(
+        "CLI dependencies are not installed. Please install kreuzberg with the 'cli' extra: pip install kreuzberg[cli]"
+    ) from e
+
+from kreuzberg import __version__, extract_bytes_sync, extract_file_sync
+from kreuzberg._cli_config import build_extraction_config, find_default_config, load_config_from_file
+from kreuzberg.exceptions import KreuzbergError, MissingDependencyError
+
+DEFAULT_MAX_CHARACTERS = 4000
+DEFAULT_MAX_OVERLAP = 200
+
+if TYPE_CHECKING:
+    from kreuzberg._types import ExtractionConfig, ExtractionResult
+
+console = Console(stderr=True)
+
+
+class OcrBackendParamType(click.ParamType):
+    """Click parameter type for OCR backend selection."""
+
+    name = "ocr_backend"
+
+    def convert(self, value: Any, param: click.Parameter | None, ctx: click.Context | None) -> str | None:
+        """Convert parameter value to OCR backend string."""
+        if value is None:
+            return None
+        if value.lower() == "none":
+            return "none"
+        valid_backends = ["tesseract", "easyocr", "paddleocr", "none"]
+        if value.lower() not in valid_backends:
+            self.fail(f"Invalid OCR backend '{value}'. Choose from: {', '.join(valid_backends)}", param, ctx)
+        return value.lower()  # type: ignore[no-any-return]
+
+
+def format_extraction_result(result: ExtractionResult, show_metadata: bool, output_format: str) -> str:
+    """Format extraction result for output.
+
+    Args:
+        result: Extraction result to format.
+        show_metadata: Whether to include metadata.
+        output_format: Output format (text, json).
+
+    Returns:
+        Formatted string.
+    """
+    if output_format == "json":
+        output_data: dict[str, Any] = {
+            "content": result.content,
+            "mime_type": result.mime_type,
+        }
+        if show_metadata:
+            output_data["metadata"] = result.metadata
+        if result.tables:
+            output_data["tables"] = result.tables
+        if result.chunks:
+            output_data["chunks"] = result.chunks
+        return json.dumps(output_data, indent=2, ensure_ascii=False)
+    # Text format
+    output_parts = [result.content]
+
+    if show_metadata:
+        output_parts.append("\n\n--- METADATA ---")
+        output_parts.append(json.dumps(result.metadata, indent=2, ensure_ascii=False))
+
+    if result.tables:
+        output_parts.append("\n\n--- TABLES ---")
+        for i, table in enumerate(result.tables):
+            output_parts.append(f"\nTable {i + 1}:")
+            output_parts.append(json.dumps(table, indent=2, ensure_ascii=False))
+
+    return "\n".join(output_parts)
+
+
+def _load_config(config: Path | None, verbose: bool) -> dict[str, Any]:
+    """Load configuration from file or find default."""
+    file_config = {}
+    if config:
+        file_config = load_config_from_file(config)
+    else:
+        # Try to find default config
+        default_config = find_default_config()
+        if default_config:
+            try:
+                file_config = load_config_from_file(default_config)
+                if verbose:
+                    console.print(f"[dim]Using configuration from: {default_config}[/dim]")
+            except Exception:  # noqa: S110, BLE001
+                # Silently ignore errors in default config
+                pass
+    return file_config
+
+
+def _build_cli_args(
+    force_ocr: bool,
+    chunk_content: bool,
+    extract_tables: bool,
+    max_chars: int,
+    max_overlap: int,
+    ocr_backend: str | None,
+    tesseract_lang: str | None,
+    tesseract_psm: int | None,
+    easyocr_languages: str | None,
+    paddleocr_languages: str | None,
+) -> dict[str, Any]:
+    """Build CLI arguments dictionary."""
+    cli_args: dict[str, Any] = {
+        "force_ocr": force_ocr if force_ocr else None,
+        "chunk_content": chunk_content if chunk_content else None,
+        "extract_tables": extract_tables if extract_tables else None,
+        "max_chars": max_chars if max_chars != DEFAULT_MAX_CHARACTERS else None,
+        "max_overlap": max_overlap if max_overlap != DEFAULT_MAX_OVERLAP else None,
+        "ocr_backend": ocr_backend,
+    }
+
+    # Handle OCR backend specific arguments
+    if ocr_backend == "tesseract" and (tesseract_lang or tesseract_psm is not None):
+        tesseract_config = {}
+        if tesseract_lang:
+            tesseract_config["language"] = tesseract_lang
+        if tesseract_psm is not None:
+            tesseract_config["psm"] = tesseract_psm  # type: ignore[assignment]
+        cli_args["tesseract_config"] = tesseract_config
+    elif ocr_backend == "easyocr" and easyocr_languages:
+        cli_args["easyocr_config"] = {"languages": easyocr_languages.split(",")}
+    elif ocr_backend == "paddleocr" and paddleocr_languages:
+        cli_args["paddleocr_config"] = {"languages": paddleocr_languages.split(",")}
+
+    return cli_args
+
+
+def _perform_extraction(file: Path | None, extraction_config: ExtractionConfig, verbose: bool) -> ExtractionResult:
+    """Perform text extraction from file or stdin."""
+    if file is None or (isinstance(file, Path) and file.name == "-"):
+        # Read from stdin
+        if verbose:
+            console.print("[dim]Reading from stdin...[/dim]")
+        try:
+            input_bytes = sys.stdin.buffer.read()
+        except Exception:  # noqa: BLE001
+            # Fallback to reading text and encoding
+            input_text = sys.stdin.read()
+            input_bytes = input_text.encode("utf-8")
+
+        with Progress(
+            SpinnerColumn(),
+            TextColumn("[progress.description]{task.description}"),
+            console=console,
+            transient=True,
+        ) as progress:
+            progress.add_task("Extracting text...", total=None)
+            # Try to detect MIME type from content, fallback to text/plain
+            try:
+                import magic  # type: ignore[import-not-found]
+
+                mime_type = magic.from_buffer(input_bytes, mime=True)
+            except ImportError:
+                # Fallback: assume text/html if it looks like HTML, otherwise text/plain
+                content_str = input_bytes.decode("utf-8", errors="ignore").lower()
+                mime_type = "text/html" if "<html" in content_str or "<body" in content_str else "text/plain"
+
+            return extract_bytes_sync(input_bytes, mime_type, config=extraction_config)
+    else:
+        # Read from file
+        with Progress(
+            SpinnerColumn(),
+            TextColumn("[progress.description]{task.description}"),
+            console=console,
+            transient=True,
+        ) as progress:
+            progress.add_task(f"Extracting text from {file.name}...", total=None)
+            return extract_file_sync(str(file), config=extraction_config)
+
+
+def _write_output(
+    result: ExtractionResult, output: Path | None, show_metadata: bool, output_format: str, verbose: bool
+) -> None:
+    """Format and write extraction output."""
+    formatted_output = format_extraction_result(result, show_metadata, output_format)
+
+    if output:
+        output.write_text(formatted_output, encoding="utf-8")
+        if verbose:
+            console.print(f"[green]✓[/green] Output written to: {output}")
+    else:
+        # Write to stdout
+        click.echo(formatted_output)
+
+
+def handle_error(error: Exception, verbose: bool) -> None:
+    """Handle and display errors.
+
+    Args:
+        error: The exception to handle.
+        verbose: Whether to show full stack trace.
+    """
+    if isinstance(error, MissingDependencyError):
+        console.print(f"[red]Missing dependency:[/red] {error}", style="bold")
+        sys.exit(2)
+    elif isinstance(error, KreuzbergError):
+        console.print(f"[red]Error:[/red] {error}", style="bold")
+        if verbose and error.context:
+            console.print("\n[dim]Context:[/dim]")
+            console.print(json.dumps(error.context, indent=2))
+        sys.exit(1)
+    else:
+        console.print(f"[red]Unexpected error:[/red] {type(error).__name__}: {error}", style="bold")
+        if verbose:
+            import traceback
+
+            console.print("\n[dim]Traceback:[/dim]")
+            traceback.print_exc()
+        sys.exit(1)
+
+
+@click.group(invoke_without_command=True)
+@click.version_option(version=__version__, prog_name="kreuzberg")
+@click.pass_context
+def cli(ctx: click.Context) -> None:
+    """Kreuzberg - Text extraction from documents.
+
+    Extract text from PDFs, images, Office documents, and more.
+    """
+    if ctx.invoked_subcommand is None:
+        click.echo(ctx.get_help())
+
+
+@cli.command()
+@click.argument("file", type=click.Path(exists=True, path_type=Path), required=False)
+@click.option("-o", "--output", type=click.Path(path_type=Path), help="Output file path (default: stdout)")
+@click.option("--force-ocr", is_flag=True, help="Force OCR processing")
+@click.option("--chunk-content", is_flag=True, help="Enable content chunking")
+@click.option("--extract-tables", is_flag=True, help="Enable table extraction")
+@click.option(
+    "--max-chars",
+    type=int,
+    default=DEFAULT_MAX_CHARACTERS,
+    help=f"Maximum characters per chunk (default: {DEFAULT_MAX_CHARACTERS})",
+)
+@click.option(
+    "--max-overlap",
+    type=int,
+    default=DEFAULT_MAX_OVERLAP,
+    help=f"Maximum overlap between chunks (default: {DEFAULT_MAX_OVERLAP})",
+)
+@click.option(
+    "--ocr-backend", type=OcrBackendParamType(), help="OCR backend to use (tesseract, easyocr, paddleocr, none)"
+)
+@click.option("--config", type=click.Path(exists=True, path_type=Path), help="Configuration file path")
+@click.option("--show-metadata", is_flag=True, help="Include metadata in output")
+@click.option("--output-format", type=click.Choice(["text", "json"]), default="text", help="Output format")
+@click.option("-v", "--verbose", is_flag=True, help="Verbose output for debugging")
+# OCR backend specific options
+@click.option("--tesseract-lang", help="Tesseract language(s) (e.g., 'eng+deu')")
+@click.option("--tesseract-psm", type=int, help="Tesseract PSM mode (0-13)")
+@click.option("--easyocr-languages", help="EasyOCR language codes (comma-separated, e.g., 'en,de')")
+@click.option("--paddleocr-languages", help="PaddleOCR language codes (comma-separated, e.g., 'en,german')")
+@click.pass_context
+def extract(  # noqa: PLR0913
+    ctx: click.Context,  # noqa: ARG001
+    file: Path | None,
+    output: Path | None,
+    force_ocr: bool,
+    chunk_content: bool,
+    extract_tables: bool,
+    max_chars: int,
+    max_overlap: int,
+    ocr_backend: str | None,
+    config: Path | None,
+    show_metadata: bool,
+    output_format: str,
+    verbose: bool,
+    tesseract_lang: str | None,
+    tesseract_psm: int | None,
+    easyocr_languages: str | None,
+    paddleocr_languages: str | None,
+) -> None:
+    """Extract text from a document.
+
+    FILE can be a path to a document or '-' to read from stdin.
+    If FILE is omitted, reads from stdin.
+    """
+    try:
+        # Load configuration
+        file_config = _load_config(config, verbose)
+
+        # Build CLI arguments dict
+        cli_args = _build_cli_args(
+            force_ocr,
+            chunk_content,
+            extract_tables,
+            max_chars,
+            max_overlap,
+            ocr_backend,
+            tesseract_lang,
+            tesseract_psm,
+            easyocr_languages,
+            paddleocr_languages,
+        )
+
+        # Build extraction config
+        extraction_config = build_extraction_config(file_config, cli_args)
+
+        # Perform extraction
+        result = _perform_extraction(file, extraction_config, verbose)
+
+        # Format and write output
+        _write_output(result, output, show_metadata, output_format, verbose)
+
+    except Exception as e:  # noqa: BLE001
+        handle_error(e, verbose)
+
+
+@cli.command()
+@click.option("--config", type=click.Path(exists=True, path_type=Path), help="Configuration file path")
+def config(config: Path | None) -> None:
+    """Show current configuration."""
+    try:
+        config_path = config or find_default_config()
+
+        if config_path:
+            file_config = load_config_from_file(config_path)
+            console.print(f"[bold]Configuration from:[/bold] {config_path}")
+            console.print(json.dumps(file_config, indent=2))
+        else:
+            console.print("[yellow]No configuration file found.[/yellow]")
+            console.print("\nDefault configuration values:")
+            console.print("  force_ocr: False")
+            console.print("  chunk_content: False")
+            console.print("  extract_tables: False")
+            console.print(f"  max_chars: {DEFAULT_MAX_CHARACTERS}")
+            console.print(f"  max_overlap: {DEFAULT_MAX_OVERLAP}")
+            console.print("  ocr_backend: tesseract")
+    except Exception as e:  # noqa: BLE001
+        handle_error(e, verbose=False)
+
+
+if __name__ == "__main__":
+    cli()

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -135,6 +135,7 @@ nav:
       - OCR Configuration: user-guide/ocr-configuration.md
       - OCR Backends: user-guide/ocr-backends.md
       - Supported Formats: user-guide/supported-formats.md
+  - CLI Guide: cli.md
   - Examples:
       - examples/index.md
       - Extraction Examples: examples/extraction-examples.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,8 @@
+[build-system]
+build-backend = "hatchling.build"
+
+requires = [ "hatchling" ]
+
 [project]
 name = "kreuzberg"
 version = "3.2.0"
@@ -49,6 +54,8 @@ dependencies = [
 ]
 
 optional-dependencies.all = [
+  # cli
+  "click>=8.1.0",
   # easyocr
   "easyocr>=1.7.2",
   # gmft
@@ -56,12 +63,19 @@ optional-dependencies.all = [
   # paddle
   "paddleocr>=3.1.0",
   "paddlepaddle>=3.1.0",
+  "rich>=13.0.0",
   # chunking
   "semantic-text-splitter>=0.27.0",
   "setuptools>=80.9.0",
+  "tomli>=2.0.0; python_version<'3.11'",
 ]
 optional-dependencies.chunking = [
   "semantic-text-splitter>=0.27.0",
+]
+optional-dependencies.cli = [
+  "click>=8.1.0",
+  "rich>=13.0.0",
+  "tomli>=2.0.0; python_version<'3.11'",
 ]
 optional-dependencies.easyocr = [
   "easyocr>=1.7.2",
@@ -75,6 +89,8 @@ optional-dependencies.paddleocr = [
   "setuptools>=80.9.0",
 ]
 urls.homepage = "https://github.com/Goldziher/kreuzberg"
+
+scripts.kreuzberg = "kreuzberg.cli:cli"
 
 [dependency-groups]
 dev = [

--- a/tests/cli_integration_test.py
+++ b/tests/cli_integration_test.py
@@ -1,0 +1,546 @@
+"""Integration tests for the CLI module."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+# Only test CLI if dependencies are available
+try:
+    import click  # noqa: F401
+    import rich  # noqa: F401
+
+    CLI_AVAILABLE = True
+except ImportError:
+    CLI_AVAILABLE = False
+
+pytestmark = pytest.mark.skipif(not CLI_AVAILABLE, reason="CLI dependencies not installed")
+
+
+class TestCliIntegration:
+    """Integration tests for CLI functionality with real files and processes."""
+
+    def test_cli_extract_html_file(self, tmp_path: Path) -> None:
+        """Test extracting from an HTML file via CLI."""
+        # Create test HTML file
+        html_file = tmp_path / "test.html"
+        html_file.write_text("""
+        <html>
+            <head><title>Test Document</title></head>
+            <body>
+                <h1>Test Heading</h1>
+                <p>This is a test paragraph with some content.</p>
+                <p>Another paragraph for testing.</p>
+            </body>
+        </html>
+        """)
+
+        # Run CLI command
+        result = subprocess.run(
+            [sys.executable, "-m", "kreuzberg", "extract", str(html_file)],
+            check=False,
+            capture_output=True,
+            text=True,
+            cwd=Path.cwd(),
+        )
+
+        assert result.returncode == 0
+        assert "Test Heading" in result.stdout
+        assert "test paragraph" in result.stdout
+        assert "Another paragraph" in result.stdout
+
+    def test_cli_extract_to_file(self, tmp_path: Path) -> None:
+        """Test extracting to an output file."""
+        # Create test markdown file
+        md_file = tmp_path / "test.md"
+        md_file.write_text("""
+        # Test Markdown
+
+        This is a **test** markdown file with some content.
+
+        - Item 1
+        - Item 2
+        - Item 3
+        """)
+
+        output_file = tmp_path / "output.txt"
+
+        # Run CLI command with output file
+        result = subprocess.run(
+            [sys.executable, "-m", "kreuzberg", "extract", str(md_file), "-o", str(output_file)],
+            check=False,
+            capture_output=True,
+            text=True,
+            cwd=Path.cwd(),
+        )
+
+        assert result.returncode == 0
+        assert output_file.exists()
+
+        content = output_file.read_text()
+        assert "Test Markdown" in content
+        assert "**test** markdown file" in content  # The markdown is preserved as-is
+        assert "Item 1" in content
+
+    def test_cli_extract_json_output_with_metadata(self, tmp_path: Path) -> None:
+        """Test JSON output format with metadata."""
+        # Create test text file
+        txt_file = tmp_path / "test.txt"
+        txt_file.write_text("This is a simple text file for testing JSON output.")
+
+        # Run CLI command with JSON output and metadata
+        result = subprocess.run(
+            [sys.executable, "-m", "kreuzberg", "extract", str(txt_file), "--output-format", "json", "--show-metadata"],
+            check=False,
+            capture_output=True,
+            text=True,
+            cwd=Path.cwd(),
+        )
+
+        assert result.returncode == 0
+
+        # Parse JSON output
+        output_data = json.loads(result.stdout)
+        assert "content" in output_data
+        assert "mime_type" in output_data
+        assert "metadata" in output_data
+        assert "simple text file" in output_data["content"]
+
+    def test_cli_extract_from_stdin(self) -> None:
+        """Test extracting from stdin."""
+        test_content = "<html><body><h1>Stdin Test</h1><p>Content from stdin</p></body></html>"
+
+        # Run CLI command with stdin input
+        result = subprocess.run(
+            [sys.executable, "-m", "kreuzberg", "extract"],
+            check=False,
+            input=test_content,
+            capture_output=True,
+            text=True,
+            cwd=Path.cwd(),
+        )
+
+        assert result.returncode == 0
+        assert "Stdin Test" in result.stdout
+        assert "Content from stdin" in result.stdout
+
+    def test_cli_with_config_file(self, tmp_path: Path) -> None:
+        """Test CLI with configuration file."""
+        # Create test document
+        html_file = tmp_path / "test.html"
+        html_file.write_text("<html><body><p>Test content for config</p></body></html>")
+
+        # Create config file
+        config_file = tmp_path / "pyproject.toml"
+        config_file.write_text("""
+[tool.kreuzberg]
+chunk_content = true
+max_chars = 200
+max_overlap = 50
+extract_tables = false
+
+[tool.kreuzberg.tesseract]
+language = "eng"
+psm = 6
+""")
+
+        # Run CLI with config file
+        result = subprocess.run(
+            [sys.executable, "-m", "kreuzberg", "extract", str(html_file), "--config", str(config_file), "--verbose"],
+            check=False,
+            capture_output=True,
+            text=True,
+            cwd=Path.cwd(),
+        )
+
+        assert result.returncode == 0
+        assert "Test content" in result.stdout
+        # Config was loaded successfully (no need to check specific message)
+
+    def test_cli_config_command(self, tmp_path: Path) -> None:
+        """Test the config command."""
+        # Create config file
+        config_file = tmp_path / "config.toml"
+        config_file.write_text("""
+[tool.kreuzberg]
+force_ocr = true
+chunk_content = false
+max_chars = 5000
+
+[tool.kreuzberg.tesseract]
+language = "eng+deu"
+psm = 3
+""")
+
+        # Run config command
+        result = subprocess.run(
+            [sys.executable, "-m", "kreuzberg", "config", "--config", str(config_file)],
+            check=False,
+            capture_output=True,
+            text=True,
+            cwd=Path.cwd(),
+        )
+
+        assert result.returncode == 0
+        # Config command outputs to stderr (Rich console)
+        output_text = result.stderr
+        assert "force_ocr" in output_text
+        assert "true" in output_text
+        assert "eng+deu" in output_text
+        assert "config.toml" in output_text  # Just check filename, not full path
+
+    def test_cli_config_command_no_file(self) -> None:
+        """Test config command when no config file exists."""
+        result = subprocess.run(
+            [sys.executable, "-m", "kreuzberg", "config"], check=False, capture_output=True, text=True, cwd=Path("/tmp")
+        )  # Use /tmp to avoid finding project config
+
+        assert result.returncode == 0
+        assert "No configuration file found" in result.stderr
+        assert "Default configuration values" in result.stderr
+
+    def test_cli_tesseract_options(self, tmp_path: Path) -> None:
+        """Test CLI with Tesseract-specific options."""
+        # Create test text file (doesn't need OCR but tests config)
+        txt_file = tmp_path / "test.txt"
+        txt_file.write_text("Simple text content for tesseract options test.")
+
+        # Run with tesseract options
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "kreuzberg",
+                "extract",
+                str(txt_file),
+                "--ocr-backend",
+                "tesseract",
+                "--tesseract-lang",
+                "eng",
+                "--tesseract-psm",
+                "6",
+            ],
+            check=False,
+            capture_output=True,
+            text=True,
+            cwd=Path.cwd(),
+        )
+
+        assert result.returncode == 0
+        assert "Simple text content" in result.stdout
+
+    def test_cli_force_ocr_option(self, tmp_path: Path) -> None:
+        """Test CLI with force OCR option."""
+        # Create test text file
+        txt_file = tmp_path / "test.txt"
+        txt_file.write_text("Text content that should be processed with OCR.")
+
+        # Run with force OCR
+        result = subprocess.run(
+            [sys.executable, "-m", "kreuzberg", "extract", str(txt_file), "--force-ocr", "--ocr-backend", "tesseract"],
+            check=False,
+            capture_output=True,
+            text=True,
+            cwd=Path.cwd(),
+        )
+
+        assert result.returncode == 0
+        assert "processed with OCR" in result.stdout
+
+    def test_cli_chunking_options(self, tmp_path: Path) -> None:
+        """Test CLI with chunking options."""
+        # Create a longer text file
+        txt_file = tmp_path / "long_text.txt"
+        long_text = "This is a test. " * 200  # Create text longer than default chunk size
+        txt_file.write_text(long_text)
+
+        # Run with chunking enabled (set overlap smaller than max-chars)
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "kreuzberg",
+                "extract",
+                str(txt_file),
+                "--chunk-content",
+                "--max-chars",
+                "200",
+                "--max-overlap",
+                "50",
+                "--output-format",
+                "json",
+            ],
+            check=False,
+            capture_output=True,
+            text=True,
+            cwd=Path.cwd(),
+        )
+
+        assert result.returncode == 0
+
+        # Parse JSON to check if chunks are created
+        output_data = json.loads(result.stdout)
+        # Note: chunks might be None if the text is not actually chunked by the backend
+        assert "content" in output_data
+
+    def test_cli_auto_config_detection(self, tmp_path: Path) -> None:
+        """Test automatic config file detection."""
+        # Create test file
+        txt_file = tmp_path / "test.txt"
+        txt_file.write_text("Content for auto config test.")
+
+        # Create pyproject.toml in the same directory
+        config_file = tmp_path / "pyproject.toml"
+        config_file.write_text("""
+[tool.kreuzberg]
+max_chars = 1500
+""")
+
+        # Run from the directory with pyproject.toml
+        result = subprocess.run(
+            [sys.executable, "-m", "kreuzberg", "extract", str(txt_file), "--verbose"],
+            check=False,
+            capture_output=True,
+            text=True,
+            cwd=tmp_path,
+        )
+
+        assert result.returncode == 0
+        assert "Content for auto config" in result.stdout
+
+    def test_cli_error_invalid_file(self) -> None:
+        """Test CLI error handling for invalid file."""
+        result = subprocess.run(
+            [sys.executable, "-m", "kreuzberg", "extract", "nonexistent.pdf"],
+            check=False,
+            capture_output=True,
+            text=True,
+            cwd=Path.cwd(),
+        )
+
+        assert result.returncode != 0
+        assert "does not exist" in result.stderr
+
+    def test_cli_error_invalid_ocr_backend(self, tmp_path: Path) -> None:
+        """Test CLI error handling for invalid OCR backend."""
+        txt_file = tmp_path / "test.txt"
+        txt_file.write_text("Test content")
+
+        result = subprocess.run(
+            [sys.executable, "-m", "kreuzberg", "extract", str(txt_file), "--ocr-backend", "invalid_backend"],
+            check=False,
+            capture_output=True,
+            text=True,
+            cwd=Path.cwd(),
+        )
+
+        assert result.returncode != 0
+        assert "Invalid OCR backend" in result.stderr
+
+    def test_cli_version_command(self) -> None:
+        """Test version command."""
+        result = subprocess.run(
+            [sys.executable, "-m", "kreuzberg", "--version"],
+            check=False,
+            capture_output=True,
+            text=True,
+            cwd=Path.cwd(),
+        )
+
+        assert result.returncode == 0
+        assert "kreuzberg, version" in result.stdout
+        assert "3.2.0" in result.stdout
+
+    def test_cli_help_command(self) -> None:
+        """Test help command."""
+        result = subprocess.run(
+            [sys.executable, "-m", "kreuzberg", "--help"], check=False, capture_output=True, text=True, cwd=Path.cwd()
+        )
+
+        assert result.returncode == 0
+        assert "Kreuzberg - Text extraction from documents" in result.stdout
+        assert "extract" in result.stdout
+        assert "config" in result.stdout
+
+    def test_cli_extract_help(self) -> None:
+        """Test extract command help."""
+        result = subprocess.run(
+            [sys.executable, "-m", "kreuzberg", "extract", "--help"],
+            check=False,
+            capture_output=True,
+            text=True,
+            cwd=Path.cwd(),
+        )
+
+        assert result.returncode == 0
+        assert "Extract text from a document" in result.stdout
+        assert "--force-ocr" in result.stdout
+        assert "--chunk-content" in result.stdout
+        assert "--extract-tables" in result.stdout
+
+    def test_cli_with_real_pdf(self, tmp_path: Path) -> None:
+        """Test CLI with a real PDF file if available."""
+        # Check if we have a PDF test file
+        pdf_files = list(Path("tests/test_source_files").glob("*.pdf"))
+        if not pdf_files:
+            pytest.skip("No PDF test files available")
+
+        pdf_file = pdf_files[0]
+        output_file = tmp_path / "pdf_output.txt"
+
+        result = subprocess.run(
+            [sys.executable, "-m", "kreuzberg", "extract", str(pdf_file), "-o", str(output_file)],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=30,
+            cwd=Path.cwd(),
+        )
+
+        # If the process was terminated by signal, skip the test
+        if result.returncode < 0:
+            pytest.skip(f"PDF extraction terminated by signal {-result.returncode}")
+
+        assert result.returncode == 0
+        assert output_file.exists()
+
+        # Check that we got some content
+        content = output_file.read_text()
+        assert len(content.strip()) > 0
+
+    def test_cli_extract_tables_option(self, tmp_path: Path) -> None:
+        """Test CLI with extract tables option."""
+        # Create simple HTML with table
+        html_file = tmp_path / "table_test.html"
+        html_file.write_text("""
+        <html>
+            <body>
+                <h1>Document with Table</h1>
+                <table>
+                    <tr><th>Name</th><th>Age</th></tr>
+                    <tr><td>John</td><td>30</td></tr>
+                    <tr><td>Jane</td><td>25</td></tr>
+                </table>
+            </body>
+        </html>
+        """)
+
+        # Run with table extraction (note: might not extract tables from HTML)
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "kreuzberg",
+                "extract",
+                str(html_file),
+                "--extract-tables",
+                "--output-format",
+                "json",
+            ],
+            check=False,
+            capture_output=True,
+            text=True,
+            cwd=Path.cwd(),
+        )
+
+        assert result.returncode == 0
+
+        output_data = json.loads(result.stdout)
+        assert "content" in output_data
+        assert "Document with Table" in output_data["content"]
+
+    def test_cli_configuration_precedence(self, tmp_path: Path) -> None:
+        """Test that CLI args override config file settings."""
+        # Create test file
+        txt_file = tmp_path / "test.txt"
+        txt_file.write_text("Test content for precedence check.")
+
+        # Create config file with chunk_content = false
+        config_file = tmp_path / "test_config.toml"
+        config_file.write_text("""
+[tool.kreuzberg]
+chunk_content = false
+max_chars = 1000
+""")
+
+        # Run CLI with --chunk-content flag (should override config)
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "kreuzberg",
+                "extract",
+                str(txt_file),
+                "--config",
+                str(config_file),
+                "--chunk-content",
+                "--output-format",
+                "json",
+            ],
+            check=False,
+            capture_output=True,
+            text=True,
+            cwd=Path.cwd(),
+        )
+
+        assert result.returncode == 0
+
+        # Verify the content was processed (even though we can't easily verify chunking)
+        output_data = json.loads(result.stdout)
+        assert "precedence check" in output_data["content"]
+
+    def test_cli_invalid_config_file(self, tmp_path: Path) -> None:
+        """Test CLI with invalid config file."""
+        txt_file = tmp_path / "test.txt"
+        txt_file.write_text("Test content")
+
+        # Create invalid TOML file
+        bad_config = tmp_path / "bad_config.toml"
+        bad_config.write_text("invalid toml content [[[")
+
+        result = subprocess.run(
+            [sys.executable, "-m", "kreuzberg", "extract", str(txt_file), "--config", str(bad_config)],
+            check=False,
+            capture_output=True,
+            text=True,
+            cwd=Path.cwd(),
+        )
+
+        assert result.returncode == 1
+        assert "Invalid TOML" in result.stderr
+
+    def test_cli_missing_config_file(self, tmp_path: Path) -> None:
+        """Test CLI with missing config file."""
+        txt_file = tmp_path / "test.txt"
+        txt_file.write_text("Test content")
+
+        result = subprocess.run(
+            [sys.executable, "-m", "kreuzberg", "extract", str(txt_file), "--config", "nonexistent_config.toml"],
+            check=False,
+            capture_output=True,
+            text=True,
+            cwd=Path.cwd(),
+        )
+
+        assert result.returncode == 2  # Click parameter validation error
+        assert "does not exist" in result.stderr
+
+    def test_cli_ocr_backend_none(self, tmp_path: Path) -> None:
+        """Test CLI with OCR backend set to none."""
+        txt_file = tmp_path / "test.txt"
+        txt_file.write_text("Simple text that should not use OCR.")
+
+        result = subprocess.run(
+            [sys.executable, "-m", "kreuzberg", "extract", str(txt_file), "--ocr-backend", "none"],
+            check=False,
+            capture_output=True,
+            text=True,
+            cwd=Path.cwd(),
+        )
+
+        assert result.returncode == 0
+        assert "should not use OCR" in result.stdout

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -1,0 +1,340 @@
+"""Tests for the CLI module."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import TYPE_CHECKING
+from unittest.mock import Mock
+
+import pytest
+from click.testing import CliRunner
+
+from kreuzberg._cli_config import (
+    build_extraction_config,
+    load_config_from_file,
+    merge_configs,
+    parse_ocr_backend_config,
+)
+from kreuzberg._ocr._tesseract import TesseractConfig
+from kreuzberg.exceptions import ValidationError
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
+
+# Only test CLI if dependencies are available
+try:
+    from kreuzberg.cli import cli
+
+    CLI_AVAILABLE = True
+except ImportError:
+    CLI_AVAILABLE = False
+
+pytestmark = pytest.mark.skipif(not CLI_AVAILABLE, reason="CLI dependencies not installed")
+
+
+class TestCliConfig:
+    """Test configuration parsing functionality."""
+
+    def test_load_config_from_file(self, tmp_path: Path) -> None:
+        """Test loading configuration from TOML file."""
+        config_file = tmp_path / "pyproject.toml"
+        config_file.write_text("""
+[tool.kreuzberg]
+force_ocr = true
+chunk_content = false
+max_chars = 5000
+
+[tool.kreuzberg.tesseract]
+lang = "eng+deu"
+psm = 3
+""")
+
+        config = load_config_from_file(config_file)
+        assert config["force_ocr"] is True
+        assert config["chunk_content"] is False
+        assert config["max_chars"] == 5000
+        assert config["tesseract"]["lang"] == "eng+deu"
+        assert config["tesseract"]["psm"] == 3
+
+    def test_load_config_file_not_found(self) -> None:
+        """Test error when config file doesn't exist."""
+        with pytest.raises(ValidationError, match="Configuration file not found"):
+            load_config_from_file(Path("nonexistent.toml"))
+
+    def test_load_config_invalid_toml(self, tmp_path: Path) -> None:
+        """Test error when config file has invalid TOML."""
+        config_file = tmp_path / "invalid.toml"
+        config_file.write_text("invalid toml content [")
+
+        with pytest.raises(ValidationError, match="Invalid TOML"):
+            load_config_from_file(config_file)
+
+    def test_merge_configs(self) -> None:
+        """Test configuration merging."""
+        base = {
+            "force_ocr": False,
+            "max_chars": 1000,
+            "tesseract": {"lang": "eng", "psm": 3},
+        }
+        override = {
+            "force_ocr": True,
+            "tesseract": {"lang": "deu"},
+        }
+
+        result = merge_configs(base, override)
+        assert result["force_ocr"] is True
+        assert result["max_chars"] == 1000
+        assert result["tesseract"]["lang"] == "deu"
+        assert result["tesseract"]["psm"] == 3
+
+    def test_parse_ocr_backend_config(self) -> None:
+        """Test parsing OCR backend configuration."""
+        config_dict = {
+            "tesseract": {"language": "eng", "psm": 3},
+            "easyocr": {"languages": ["en", "de"]},
+        }
+
+        # Test tesseract config
+        tesseract_config = parse_ocr_backend_config(config_dict, "tesseract")
+        assert isinstance(tesseract_config, TesseractConfig)
+        assert tesseract_config.language == "eng"
+        assert tesseract_config.psm.value == 3
+
+        # Test non-existent backend
+        assert parse_ocr_backend_config(config_dict, "paddleocr") is None
+
+    def test_build_extraction_config(self) -> None:
+        """Test building ExtractionConfig from file and CLI args."""
+        file_config = {
+            "force_ocr": True,
+            "chunk_content": False,
+            "max_chars": 5000,
+            "tesseract": {"language": "eng"},
+        }
+        cli_args = {
+            "chunk_content": True,  # Override file config
+            "ocr_backend": "tesseract",
+            "tesseract_config": {"psm": 6},  # Additional config
+        }
+
+        config = build_extraction_config(file_config, cli_args)
+        assert config.force_ocr is True  # From file
+        assert config.chunk_content is True  # Overridden by CLI
+        assert config.max_chars == 5000  # From file
+        assert config.ocr_backend == "tesseract"
+        assert isinstance(config.ocr_config, TesseractConfig)
+        assert config.ocr_config.language == "eng"  # From file
+        assert config.ocr_config.psm.value == 6  # From CLI
+
+    def test_build_extraction_config_ocr_none(self) -> None:
+        """Test building config with OCR disabled."""
+        cli_args = {"ocr_backend": "none"}
+        config = build_extraction_config({}, cli_args)
+        assert config.ocr_backend is None
+
+
+class TestCli:
+    """Test CLI commands."""
+
+    def test_cli_help(self) -> None:
+        """Test CLI help output."""
+        runner = CliRunner()
+        result = runner.invoke(cli, ["--help"])
+        assert result.exit_code == 0
+        assert "Kreuzberg - Text extraction from documents" in result.output
+
+    def test_cli_version(self) -> None:
+        """Test CLI version output."""
+        runner = CliRunner()
+        result = runner.invoke(cli, ["--version"])
+        assert result.exit_code == 0
+        assert "kreuzberg, version" in result.output
+
+    def test_extract_file(self, tmp_path: Path, mocker: MockerFixture) -> None:
+        """Test extracting from a file."""
+        # Create test file
+        test_file = tmp_path / "test.pdf"
+        test_file.write_bytes(b"dummy content")
+
+        # Mock extraction function
+        mock_result = Mock()
+        mock_result.content = "Extracted text content"
+        mock_result.mime_type = "application/pdf"
+        mock_result.metadata = {"pages": 1}
+        mock_result.tables = None
+        mock_result.chunks = None
+
+        mocker.patch("kreuzberg.cli.extract_file_sync", return_value=mock_result)
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["extract", str(test_file)])
+
+        assert result.exit_code == 0
+        assert "Extracted text content" in result.output
+
+    def test_extract_file_with_output(self, tmp_path: Path, mocker: MockerFixture) -> None:
+        """Test extracting to an output file."""
+        test_file = tmp_path / "test.pdf"
+        test_file.write_bytes(b"dummy content")
+        output_file = tmp_path / "output.txt"
+
+        mock_result = Mock()
+        mock_result.content = "Extracted text"
+        mock_result.mime_type = "application/pdf"
+        mock_result.metadata = {}
+        mock_result.tables = None
+        mock_result.chunks = None
+
+        mocker.patch("kreuzberg.cli.extract_file_sync", return_value=mock_result)
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["extract", str(test_file), "-o", str(output_file)])
+
+        assert result.exit_code == 0
+        assert output_file.read_text() == "Extracted text"
+
+    def test_extract_stdin(self, mocker: MockerFixture) -> None:
+        """Test extracting from stdin."""
+        mock_result = Mock()
+        mock_result.content = "Text from stdin"
+        mock_result.mime_type = "text/plain"
+        mock_result.metadata = {}
+        mock_result.tables = None
+        mock_result.chunks = None
+
+        mocker.patch("kreuzberg.cli.extract_bytes_sync", return_value=mock_result)
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["extract"], input=b"test content")
+
+        assert result.exit_code == 0
+        assert "Text from stdin" in result.output
+
+    def test_extract_with_options(self, tmp_path: Path, mocker: MockerFixture) -> None:
+        """Test extraction with various options."""
+        test_file = tmp_path / "test.pdf"
+        test_file.write_bytes(b"dummy")
+
+        mock_result = Mock()
+        mock_result.content = "Content"
+        mock_result.mime_type = "application/pdf"
+        mock_result.metadata = {"test": "value"}
+        mock_result.tables = [{"data": [[1, 2], [3, 4]]}]
+        mock_result.chunks = None
+
+        extract_mock = mocker.patch("kreuzberg.cli.extract_file_sync", return_value=mock_result)
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "extract",
+                str(test_file),
+                "--force-ocr",
+                "--chunk-content",
+                "--extract-tables",
+                "--ocr-backend",
+                "easyocr",
+                "--show-metadata",
+                "--output-format",
+                "json",
+            ],
+        )
+
+        assert result.exit_code == 0
+
+        # Check that config was built correctly
+        extract_mock.assert_called_once()
+        config = extract_mock.call_args[1]["config"]
+        assert config.force_ocr is True
+        assert config.chunk_content is True
+        assert config.extract_tables is True
+        assert config.ocr_backend == "easyocr"
+
+        # Check JSON output
+        output_data = json.loads(result.output)
+        assert output_data["content"] == "Content"
+        assert output_data["metadata"] == {"test": "value"}
+        assert output_data["tables"] == [{"data": [[1, 2], [3, 4]]}]
+
+    def test_extract_with_config_file(self, tmp_path: Path, mocker: MockerFixture) -> None:
+        """Test extraction with config file."""
+        test_file = tmp_path / "test.pdf"
+        test_file.write_bytes(b"dummy")
+
+        config_file = tmp_path / "config.toml"
+        config_file.write_text("""
+[tool.kreuzberg]
+force_ocr = true
+max_chars = 2000
+""")
+
+        mock_result = Mock()
+        mock_result.content = "Content"
+        mock_result.mime_type = "application/pdf"
+        mock_result.metadata = {}
+        mock_result.tables = None
+        mock_result.chunks = None
+
+        extract_mock = mocker.patch("kreuzberg.cli.extract_file_sync", return_value=mock_result)
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["extract", str(test_file), "--config", str(config_file)])
+
+        assert result.exit_code == 0
+        config = extract_mock.call_args[1]["config"]
+        assert config.force_ocr is True
+        assert config.max_chars == 2000
+
+    def test_config_command(self, tmp_path: Path) -> None:
+        """Test config command."""
+        config_file = tmp_path / "pyproject.toml"
+        config_file.write_text("""
+[tool.kreuzberg]
+force_ocr = true
+chunk_content = false
+""")
+
+        runner = CliRunner()
+        with runner.isolated_filesystem(temp_dir=tmp_path):
+            result = runner.invoke(cli, ["config"])
+
+        assert result.exit_code == 0
+        assert "force_ocr" in result.output
+
+    def test_error_handling(self, tmp_path: Path, mocker: MockerFixture) -> None:
+        """Test error handling."""
+        from kreuzberg.exceptions import ParsingError
+
+        test_file = tmp_path / "test.pdf"
+        test_file.write_bytes(b"dummy")
+
+        mocker.patch("kreuzberg.cli.extract_file_sync", side_effect=ParsingError("Failed to parse"))
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["extract", str(test_file)])
+
+        assert result.exit_code == 1
+        assert "Error:" in result.output
+        assert "Failed to parse" in result.output
+
+    def test_missing_dependency_error(self, tmp_path: Path, mocker: MockerFixture) -> None:
+        """Test missing dependency error handling."""
+        from kreuzberg.exceptions import MissingDependencyError
+
+        test_file = tmp_path / "test.pdf"
+        test_file.write_bytes(b"dummy")
+
+        mocker.patch(
+            "kreuzberg.cli.extract_file_sync",
+            side_effect=MissingDependencyError.create_for_package(
+                dependency_group="easyocr", functionality="OCR processing", package_name="easyocr"
+            ),
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["extract", str(test_file)])
+
+        assert result.exit_code == 2
+        assert "Missing dependency:" in result.output

--- a/uv.lock
+++ b/uv.lock
@@ -1742,7 +1742,7 @@ wheels = [
 [[package]]
 name = "kreuzberg"
 version = "3.2.0"
-source = { virtual = "." }
+source = { editable = "." }
 dependencies = [
     { name = "anyio" },
     { name = "charset-normalizer" },
@@ -1757,15 +1757,25 @@ dependencies = [
 
 [package.optional-dependencies]
 all = [
+    { name = "click", version = "8.1.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "click", version = "8.2.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "easyocr" },
     { name = "gmft" },
     { name = "paddleocr" },
     { name = "paddlepaddle" },
+    { name = "rich" },
     { name = "semantic-text-splitter" },
     { name = "setuptools" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
 chunking = [
     { name = "semantic-text-splitter" },
+]
+cli = [
+    { name = "click", version = "8.1.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "click", version = "8.2.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "rich" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
 easyocr = [
     { name = "easyocr" },
@@ -1804,6 +1814,8 @@ doc = [
 requires-dist = [
     { name = "anyio", specifier = ">=4.9.0" },
     { name = "charset-normalizer", specifier = ">=3.4.2" },
+    { name = "click", marker = "extra == 'all'", specifier = ">=8.1.0" },
+    { name = "click", marker = "extra == 'cli'", specifier = ">=8.1.0" },
     { name = "easyocr", marker = "extra == 'all'", specifier = ">=1.7.2" },
     { name = "easyocr", marker = "extra == 'easyocr'", specifier = ">=1.7.2" },
     { name = "exceptiongroup", marker = "python_full_version < '3.11'", specifier = ">=1.2.2" },
@@ -1818,13 +1830,17 @@ requires-dist = [
     { name = "pypdfium2", specifier = "==4.30.0" },
     { name = "python-calamine", specifier = ">=0.3.2" },
     { name = "python-pptx", specifier = ">=1.0.2" },
+    { name = "rich", marker = "extra == 'all'", specifier = ">=13.0.0" },
+    { name = "rich", marker = "extra == 'cli'", specifier = ">=13.0.0" },
     { name = "semantic-text-splitter", marker = "extra == 'all'", specifier = ">=0.27.0" },
     { name = "semantic-text-splitter", marker = "extra == 'chunking'", specifier = ">=0.27.0" },
     { name = "setuptools", marker = "extra == 'all'", specifier = ">=80.9.0" },
     { name = "setuptools", marker = "extra == 'paddleocr'", specifier = ">=80.9.0" },
+    { name = "tomli", marker = "python_full_version < '3.11' and extra == 'all'", specifier = ">=2.0.0" },
+    { name = "tomli", marker = "python_full_version < '3.11' and extra == 'cli'", specifier = ">=2.0.0" },
     { name = "typing-extensions", marker = "python_full_version < '3.12'", specifier = ">=4.14.0" },
 ]
-provides-extras = ["all", "chunking", "easyocr", "gmft", "paddleocr"]
+provides-extras = ["all", "chunking", "easyocr", "gmft", "paddleocr", "cli"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -2068,6 +2084,18 @@ wheels = [
 ]
 
 [[package]]
+name = "markdown-it-py"
+version = "3.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/38/71/3b932df36c1a044d397a1f92d1cf91ee0a503d91e470cbd670aa66b07ed0/markdown-it-py-3.0.0.tar.gz", hash = "sha256:e3f60a94fa066dc52ec76661e37c851cb232d92f9886b15cb560aaada2df8feb", size = 74596, upload-time = "2023-06-03T06:41:14.443Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/42/d7/1ec15b46af6af88f19b8e5ffea08fa375d433c998b8a7639e76935c14f1f/markdown_it_py-3.0.0-py3-none-any.whl", hash = "sha256:355216845c60bd96232cd8d8c40e8f9765cc86f46880e43a8fd22dc1a1a8cab1", size = 87528, upload-time = "2023-06-03T06:41:11.019Z" },
+]
+
+[[package]]
 name = "markupsafe"
 version = "3.0.2"
 source = { registry = "https://pypi.org/simple" }
@@ -2277,6 +2305,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/3d/d1/f54d43e95384b312ffa4a74a4326c722f3b8187aaaa12e9a84cdf3037131/matplotlib-3.10.3-pp310-pypy310_pp73-macosx_10_15_x86_64.whl", hash = "sha256:86ab63d66bbc83fdb6733471d3bff40897c1e9921cba112accd748eee4bce5e4", size = 8162896, upload-time = "2025-05-08T19:10:46.432Z" },
     { url = "https://files.pythonhosted.org/packages/24/a4/fbfc00c2346177c95b353dcf9b5a004106abe8730a62cb6f27e79df0a698/matplotlib-3.10.3-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:a48f9c08bf7444b5d2391a83e75edb464ccda3c380384b36532a0962593a1751", size = 8039702, upload-time = "2025-05-08T19:10:49.634Z" },
     { url = "https://files.pythonhosted.org/packages/6a/b9/59e120d24a2ec5fc2d30646adb2efb4621aab3c6d83d66fb2a7a182db032/matplotlib-3.10.3-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cb73d8aa75a237457988f9765e4dfe1c0d2453c5ca4eabc897d4309672c8e014", size = 8594298, upload-time = "2025-05-08T19:10:51.738Z" },
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
 ]
 
 [[package]]
@@ -4439,6 +4476,20 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/f3/61/d7545dafb7ac2230c70d38d31cbfe4cc64f7144dc41f6e4e4b78ecd9f5bb/requests-toolbelt-1.0.0.tar.gz", hash = "sha256:7681a0a3d047012b5bdc0ee37d7f8f07ebe76ab08caeccfc3921ce23c88d5bc6", size = 206888, upload-time = "2023-05-01T04:11:33.229Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3f/51/d4db610ef29373b879047326cbf6fa98b6c1969d6f6dc423279de2b1be2c/requests_toolbelt-1.0.0-py2.py3-none-any.whl", hash = "sha256:cccfdd665f0a24fcf4726e690f65639d272bb0637b9b92dfd91a5568ccf6bd06", size = 54481, upload-time = "2023-05-01T04:11:28.427Z" },
+]
+
+[[package]]
+name = "rich"
+version = "14.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "pygments" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a1/53/830aa4c3066a8ab0ae9a9955976fb770fe9c6102117c8ec4ab3ea62d89e8/rich-14.0.0.tar.gz", hash = "sha256:82f1bc23a6a21ebca4ae0c45af9bdbc492ed20231dcb63f297d6d1021a9d5725", size = 224078, upload-time = "2025-03-30T14:15:14.23Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0d/9b/63f4c7ebc259242c89b3acafdb37b41d1185c07ff0011164674e9076b491/rich-14.0.0-py3-none-any.whl", hash = "sha256:1c9491e1951aac09caffd42f448ee3d04e58923ffe14993f6e83068dc395d7e0", size = 243229, upload-time = "2025-03-30T14:15:12.283Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Implements a comprehensive command-line interface for the kreuzberg text extraction library, addressing issue #63.

### Key Features
- **CLI Framework**: Built with Click for robust command-line parsing and user experience
- **Flexible Input**: Support for file paths, stdin input, and `-` argument for stdin
- **Output Formats**: JSON and text output with optional metadata inclusion
- **Configuration**: TOML configuration file support with CLI argument override
- **OCR Integration**: Backend selection and configuration for Tesseract, EasyOCR, and PaddleOCR
- **Rich Console**: Progress indicators, error formatting, and colored output
- **Entry Points**: Both `kreuzberg` command and `python -m kreuzberg` execution

### Implementation Details
- **Configuration Parsing**: Hierarchical config merging (defaults < file < CLI args)
- **Error Handling**: Comprehensive exception handling with context information
- **Type Safety**: Full mypy compliance with proper type annotations
- **Testing**: 39 tests total (17 unit + 22 integration) with real subprocess testing

### Files Added
- `kreuzberg/cli.py` - Main CLI implementation
- `kreuzberg/_cli_config.py` - Configuration parsing logic
- `kreuzberg/__main__.py` - Module execution entry point
- `tests/cli_test.py` - Unit tests for CLI functionality
- `tests/cli_integration_test.py` - Integration tests with real subprocess execution
- `docs/cli.md` - Complete CLI documentation

### Configuration Example
```toml
[tool.kreuzberg]
force_ocr = true
chunk_content = false
extract_tables = true
max_chars = 4000
ocr_backend = "tesseract"

[tool.kreuzberg.tesseract]
language = "eng+deu"
psm = 3
```

### Usage Examples
```bash
# Extract from file
kreuzberg extract document.pdf

# Extract with JSON output and metadata
kreuzberg extract document.pdf --output-format json --show-metadata

# Extract from stdin
cat document.html | kreuzberg extract

# Use specific OCR backend
kreuzberg extract image.png --ocr-backend easyocr --easyocr-languages en,de
```

## Test Plan
- [x] Unit tests for configuration parsing and CLI logic
- [x] Integration tests with real subprocess execution
- [x] Configuration file parsing and precedence
- [x] Stdin/stdout handling
- [x] Error condition coverage
- [x] OCR backend configuration
- [x] All pre-commit hooks passing (ruff, mypy, etc.)

🤖 Generated with [Claude Code](https://claude.ai/code)