### PR TITLE
feat: add crypto extra for more PDF coverage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ dependencies = [
   "html-to-markdown[lxml]>=1.8.0",
   "mcp>=1.11.0",
   "msgspec>=0.18.0",
-  "playa-pdf>=0.6.1",                                 # pinned due to breaking changes in 0.5.0
+  "playa-pdf[crypto]>=0.6.1",                         # pinned due to breaking changes in 0.5.0
   "psutil>=7.0.0",
   "pypdfium2==4.30.0",                                # pinned due to bug in 4.30.1, until v5 is stable
   "python-calamine>=0.3.2",


### PR DESCRIPTION
Some pdfs on my disk cause an error when trying them with Kreuzberg, mentioning the `crypto` extra for playa-pdf. Is it a bad idea to add it?