### PR TITLE
docs: fix table attribute access in documentation

### DIFF
--- a/docs/examples/extraction-examples.md
+++ b/docs/examples/extraction-examples.md
@@ -132,15 +132,15 @@ async def extract_tables_from_pdf():
     # Process extracted tables
     print(f"Found {len(result.tables)} tables")
     for i, table in enumerate(result.tables):
-        print(f"Table {i+1} on page {table.page_number}:")
-        print(table.text)  # Markdown formatted table
+        print(f"Table {i+1} on page {table['page_number']}:")
+        print(table['text'])  # Markdown formatted table
 
         # Work with the pandas DataFrame
-        df = table.df
+        df = table['df']
         print(f"Table shape: {df.shape}")
 
         # The cropped table image is also available
-        # table.cropped_image.save(f"table_{i+1}.png")
+        # table['cropped_image'].save(f"table_{i+1}.png")
 
     # With custom GMFT configuration
     custom_config = ExtractionConfig(

--- a/docs/user-guide/extraction-configuration.md
+++ b/docs/user-guide/extraction-configuration.md
@@ -237,10 +237,10 @@ result = await extract_file("document_with_tables.pdf", config=config)
 
 # Access extracted tables
 for i, table in enumerate(result.tables):
-    print(f"Table {i+1} on page {table.page_number}:")
-    print(table.text)  # Markdown formatted table text
+    print(f"Table {i+1} on page {table['page_number']}:")
+    print(table['text'])  # Markdown formatted table text
     # You can also access the pandas DataFrame directly
-    df = table.df
+    df = table['df']
     print(df.shape)  # (rows, columns)
 ```
 


### PR DESCRIPTION
Fix incorrect table attribute access (table.field) to correct dictionary access (table['field']) in documentation examples. Tables are returned as TypedDict objects, not objects with attributes.

🤖 Generated with [Claude Code](https://claude.ai/code)