### PR TITLE
fix: Enable running `kreuzberg` without `numpy` installed

### DIFF
--- a/kreuzberg/_ocr/_easyocr.py
+++ b/kreuzberg/_ocr/_easyocr.py
@@ -4,7 +4,6 @@ import warnings
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, ClassVar, Final, Literal
 
-import numpy as np
 from PIL import Image
 
 from kreuzberg._mime_types import PLAIN_TEXT_MIME_TYPE
@@ -455,6 +454,8 @@ class EasyOCRBackend(OCRBackend[EasyOCRConfig]):
         Raises:
             OCRError: If OCR processing fails.
         """
+        import numpy as np  # noqa: PLC0415
+
         self._init_easyocr_sync(**kwargs)
 
         beam_width = kwargs.pop("beam_width")

--- a/kreuzberg/_ocr/_paddleocr.py
+++ b/kreuzberg/_ocr/_paddleocr.py
@@ -7,7 +7,6 @@ from importlib.util import find_spec
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, ClassVar, Final, Literal
 
-import numpy as np
 from PIL import Image
 
 from kreuzberg._mime_types import PLAIN_TEXT_MIME_TYPE
@@ -380,6 +379,8 @@ class PaddleBackend(OCRBackend[PaddleOCRConfig]):
         Raises:
             OCRError: If OCR processing fails.
         """
+        import numpy as np  # noqa: PLC0415
+
         self._init_paddle_ocr_sync(**kwargs)
 
         if image.mode != "RGB":


### PR DESCRIPTION
Fixes #99 

- import `numpy` inside `EasyOCRBackend.process_image_sync` and `PaddleBackend.process_image_sync` rather than at the module level (following what is done for `EasyOCRBackend.process_image` and `PaddleBackend.process_image`)