### PR TITLE
fix: Docker permissions and improve documentation

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -46,9 +46,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 COPY --from=builder /app/.venv /app/.venv
 COPY --from=builder /app/kreuzberg /app/kreuzberg
 
-# Create non-root user
+# Create non-root user and cache directory
 RUN groupadd -r appuser && useradd -r -g appuser -d /app -s /sbin/nologin appuser && \
+    mkdir -p /app/.kreuzberg && \
     chown -R appuser:appuser /app
+
+# Set default cache directory to prevent permission issues
+ENV KREUZBERG_CACHE_DIR=/app/.kreuzberg
 
 USER appuser
 CMD ["litestar", "--app", "kreuzberg._api.main:app", "run", "--host", "0.0.0.0"]

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -1,0 +1,37 @@
+services:
+  kreuzberg:
+    # Choose your image variant:
+    # - goldziher/kreuzberg:latest (core, 270MB)
+    # - goldziher/kreuzberg:latest-paddle (+ PaddleOCR, 878MB)
+    # - goldziher/kreuzberg:latest-easyocr (+ EasyOCR, 8.7GB)
+    # - goldziher/kreuzberg:latest-gmft (+ table extraction, 8.6GB)
+    # - goldziher/kreuzberg:latest-all (all features, 9.6GB - testing only!)
+    image: goldziher/kreuzberg:latest
+
+    ports:
+      - "8000:8000"
+
+    volumes:
+      # Mount your configuration file (optional)
+      - "./kreuzberg.toml:/app/kreuzberg.toml:ro"
+      # Persist cache across restarts (recommended)
+      - "kreuzberg-cache:/app/.kreuzberg"
+
+    environment:
+      - PYTHONUNBUFFERED=1
+      - KREUZBERG_CACHE_DIR=/app/.kreuzberg
+      # Optional: Cache size limits
+      # - KREUZBERG_OCR_CACHE_SIZE_MB=500
+      # - KREUZBERG_DOCUMENT_CACHE_SIZE_MB=1000
+
+    restart: unless-stopped
+
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s
+
+volumes:
+  kreuzberg-cache:

--- a/kreuzberg/cli.py
+++ b/kreuzberg/cli.py
@@ -19,10 +19,8 @@ except ImportError as e:  # pragma: no cover
 
 from kreuzberg import __version__, extract_bytes_sync, extract_file_sync
 from kreuzberg._config import build_extraction_config, find_config_file, load_config_from_file
+from kreuzberg._constants import DEFAULT_MAX_CHARACTERS, DEFAULT_MAX_OVERLAP
 from kreuzberg.exceptions import KreuzbergError, MissingDependencyError
-
-DEFAULT_MAX_CHARACTERS = 4000
-DEFAULT_MAX_OVERLAP = 200
 
 if TYPE_CHECKING:
     from kreuzberg._types import ExtractionConfig, ExtractionResult

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ requires = [ "hatchling" ]
 
 [project]
 name = "kreuzberg"
-version = "3.11.3"
+version = "3.11.4"
 description = "Document intelligence framework for Python - Extract text, metadata, and structured data from diverse file formats"
 readme = "README.md"
 keywords = [

--- a/uv.lock
+++ b/uv.lock
@@ -1632,7 +1632,7 @@ wheels = [
 
 [[package]]
 name = "kreuzberg"
-version = "3.11.3"
+version = "3.11.4"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },


### PR DESCRIPTION
## Summary
- Fix cache directory permissions issue reported by users
- Improve Docker documentation clarity and examples
- Bump version to 3.11.4

## Changes
- Pre-create /app/.kreuzberg directory with proper ownership in Docker image
- Add KREUZBERG_CACHE_DIR environment variable support (already existed, now documented)
- Clarify Docker image variants and mark 'all' image as testing-only
- Update customization examples to mount configs externally (not bake into image)
- Fix CLI to import constants from _constants.py instead of redefining them
- Add docker-compose.example.yml with best practices

## Context
Users reported permission errors when using the 'all' Docker image with mounted volumes. The cache system was trying to create .kreuzberg directory but didn't have permissions when volumes were mounted.

## Test Plan
- [x] Built and tested custom Docker images with examples
- [x] Verified chunking works with proper dependencies
- [x] Tested volume mounting and cache persistence
- [x] Confirmed environment variables work correctly

Fixes permission issue reported in Discord.