### PR TITLE
fix: improve spaCy model auto-download with uv fallback

### DIFF
--- a/kreuzberg/_entity_extraction.py
+++ b/kreuzberg/_entity_extraction.py
@@ -2,17 +2,75 @@ from __future__ import annotations
 
 import os
 import re
+import shutil
 import subprocess
-import sys
 from functools import lru_cache
 from itertools import chain
 from typing import TYPE_CHECKING, Any
 
+import anyio
+
 from kreuzberg._types import Entity, SpacyEntityExtractionConfig
+from kreuzberg._utils._sync import run_sync
 from kreuzberg.exceptions import KreuzbergError, MissingDependencyError
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
+
+
+def is_uv_available() -> bool:
+    """Check if uv is available in the environment."""
+    return shutil.which("uv") is not None
+
+
+def get_spacy_model_url(model_name: str, version: str = "3.8.0") -> str:
+    """Get the direct download URL for a spaCy model.
+
+    Args:
+        model_name: Name of the spaCy model (e.g., 'en_core_web_sm')
+        version: Model version to download (default: 3.8.0)
+
+    Returns:
+        Direct download URL for the model
+    """
+    return f"https://github.com/explosion/spacy-models/releases/download/{model_name}-{version}/{model_name}-{version}-py3-none-any.whl"
+
+
+async def install_spacy_model_with_uv(model_name: str) -> subprocess.CompletedProcess[str]:
+    """Install spaCy model using uv.
+
+    Args:
+        model_name: Name of the spaCy model to install
+
+    Returns:
+        Completed process result
+    """
+    model_url = get_spacy_model_url(model_name)
+    return await run_sync(
+        subprocess.run,
+        ["uv", "pip", "install", model_url],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+async def install_spacy_model_with_spacy(model_name: str) -> bool:
+    """Install spaCy model using spacy download function.
+
+    Args:
+        model_name: Name of the spaCy model to install
+
+    Returns:
+        True if successful, False otherwise
+    """
+    try:
+        import spacy.cli.download  # noqa: PLC0415
+
+        await run_sync(spacy.cli.download, model_name)  # type: ignore[attr-defined]
+        return True
+    except (ImportError, OSError, RuntimeError):
+        return False
 
 
 def extract_entities(
@@ -46,11 +104,11 @@ def extract_entities(
             functionality="Entity Extraction",
         ) from e
 
-    model_name = _select_spacy_model(languages, spacy_config)
+    model_name = select_spacy_model(languages, spacy_config)
     if not model_name:
         return entities
 
-    nlp = _load_spacy_model(model_name, spacy_config)
+    nlp = load_spacy_model(model_name, spacy_config)
 
     if len(text) > spacy_config.max_doc_length:
         text = text[: spacy_config.max_doc_length]
@@ -74,7 +132,7 @@ def extract_entities(
 
 
 @lru_cache(maxsize=32)
-def _load_spacy_model(model_name: str, spacy_config: SpacyEntityExtractionConfig) -> Any:
+def load_spacy_model(model_name: str, spacy_config: SpacyEntityExtractionConfig) -> Any:
     try:
         import spacy  # noqa: PLC0415
     except ImportError:
@@ -86,22 +144,58 @@ def _load_spacy_model(model_name: str, spacy_config: SpacyEntityExtractionConfig
     try:
         nlp = spacy.load(model_name)
     except OSError:
-        result = subprocess.run(
-            [sys.executable, "-m", "spacy", "download", model_name],
-            capture_output=True,
-            text=True,
-            check=False,
-        )
+        # Try to download the model automatically
+        async def install_model() -> tuple[bool, str | None]:
+            """Install model and return success status and error message."""
+            # First try spaCy's built-in download
+            try:
+                success = await install_spacy_model_with_spacy(model_name)
+                if success:
+                    return True, None
+            except (ImportError, OSError, RuntimeError) as e:
+                spacy_error = str(e)
+            else:
+                spacy_error = "spaCy download failed"
 
-        if result.returncode != 0:
+            # If spaCy download failed and uv is available, try uv as fallback
+            if is_uv_available():
+                try:
+                    result = await install_spacy_model_with_uv(model_name)
+                    return result.returncode == 0, result.stderr
+                except (OSError, subprocess.SubprocessError) as e:
+                    return False, f"spaCy: {spacy_error}, uv: {e!s}"
+
+            return False, spacy_error
+
+        # Run the async installation in a sync context
+        try:
+            success, error_details = anyio.run(install_model)
+        except (OSError, RuntimeError) as e:
+            success, error_details = False, str(e)
+
+        if not success:
+            # Generate appropriate error message based on available tools
+            if is_uv_available():
+                model_url = get_spacy_model_url(model_name)
+                manual_install_cmd = f"uv pip install {model_url}"
+            else:
+                manual_install_cmd = f"python -m spacy download {model_name}"
+
             error_msg = (
-                f"Failed to download spaCy model '{model_name}'. "
-                f"Please install it manually with: python -m spacy download {model_name}"
+                f"Failed to download spaCy model '{model_name}'. Please install it manually with: {manual_install_cmd}"
             )
-            if result.stderr:
-                error_msg += f"\nError details: {result.stderr}"
+
+            if error_details:
+                error_msg += f"\nError details: {error_details}"
+
             raise KreuzbergError(
-                error_msg, context={"model": model_name, "stderr": result.stderr, "return_code": result.returncode}
+                error_msg,
+                context={
+                    "model": model_name,
+                    "manual_install_cmd": manual_install_cmd,
+                    "error_details": error_details,
+                    "uv_available": is_uv_available(),
+                },
             ) from None
 
         try:
@@ -118,7 +212,7 @@ def _load_spacy_model(model_name: str, spacy_config: SpacyEntityExtractionConfig
     return nlp
 
 
-def _select_spacy_model(languages: list[str] | None, spacy_config: SpacyEntityExtractionConfig) -> str | None:
+def select_spacy_model(languages: list[str] | None, spacy_config: SpacyEntityExtractionConfig) -> str | None:
     if not languages:
         return spacy_config.get_model_for_language("en")
 


### PR DESCRIPTION
## Summary
- Add uv package manager fallback when spaCy programmatic download fails
- Make private functions public to enable proper testing  
- Simplify package manager detection to only check uv availability
- Support all spaCy language models via dynamic URL generation
- Update tests to use public function names and remove private function tests
- Fix linting issues with specific exception handling

## Test plan
- [x] All existing entity extraction tests pass
- [x] New tests for public utility functions
- [x] Tests cover uv fallback functionality via mocking
- [x] Linting and type checking pass

Fixes #145